### PR TITLE
Autocofus on puzzle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -94,7 +94,9 @@
           <code>
             Muzzle.basic(3, 3, './torta_1_sinborde.svg').then(it => {
               it.solve();
+              solved.resetCoordinates();
               it.redraw();
+              solved.focus();
             });
           </code>
         </pre>
@@ -102,7 +104,9 @@
           const solved = Muzzle.another('muzzle-canvas-solved');
           solved.basic(3, 3, './torta_1_sinborde.svg').then(it => {
             it.solve();
+            solved.resetCoordinates();
             it.redraw();
+            solved.focus();
           });
           solved.onSubmit = (solutionJson, valid) => {
             alert('I am going to submit solution');

--- a/lib/public/js/muzzle.js
+++ b/lib/public/js/muzzle.js
@@ -177,7 +177,7 @@ class MuzzleCanvas {
       width: this.canvasWidth,
       height: this.canvasHeight,
       pieceSize: pieceSize,
-      proximity: pieceSize.x / 5,
+      proximity: Math.min(pieceSize.x, pieceSize.y) / 5,
       borderFill: this.borderFill === null ? headbreaker.Vector.divide(pieceSize, 10) : this.borderFill,
       strokeWidth: this.strokeWidth,
       lineSoftness: 0.18

--- a/lib/public/js/muzzle.js
+++ b/lib/public/js/muzzle.js
@@ -420,9 +420,38 @@ class MuzzleCanvas {
 
   scale(width, height) {
     if (this.fixedDimensions || !this.canvas) return;
+    const factor = this.optimalScaleFactor(width, height);
     this.canvas.resize(width, height);
-    this.canvas.scale(this.optimalScaleFactor(width, height));
+    this.canvas.scale(factor);
     this.canvas.redraw();
+    this.focus();
+  }
+
+  focus() {
+    const stage = this.canvas['__konvaLayer__'].getStage();
+
+    const area = headbreaker.Vector.divide(headbreaker.vector(stage.width(), stage.height()), stage.scaleX());
+    const realDiameter = (() => {
+      const [xs, ys] = this.coordinates;
+
+      const minX = Math.min(...xs);
+      const minY = Math.min(...ys);
+
+      const maxX = Math.max(...xs);
+      const maxY = Math.max(...ys);
+
+      return headbreaker.Vector.plus(headbreaker.vector(maxX - minX, maxY - minY), this.canvas.puzzle.pieceDiameter);
+    })();
+    const diff = headbreaker.Vector.minus(area, realDiameter);
+    const semi = headbreaker.Vector.divide(diff, -2);
+
+    stage.setOffset(semi);
+    stage.draw();
+  }
+
+  get coordinates() {
+    const points = this.canvas.puzzle.points;
+    return [points.map(([x, _y]) => x), points.map(([_x, y]) => y)];
   }
 
   optimalScaleFactor(width, height) {
@@ -436,6 +465,7 @@ class MuzzleCanvas {
    */
   ready() {
     this.loadPreviousSolution();
+    this.resetCoordinates();
     this.draw();
     this.onReady();
   }
@@ -476,6 +506,13 @@ class MuzzleCanvas {
         console.warn("Ignoring unparseabe editor value");
       }
     }
+  }
+
+  resetCoordinates() {
+    const [xs, ys] = this.coordinates;
+    const minX = Math.min(...xs);
+    const minY = Math.min(...ys);
+    this.canvas.puzzle.translate(-minX, -minY);
   }
 
   // ==========


### PR DESCRIPTION
# :dart: Goal

The goal  of this PR is to automatically focus puzzle on canvas, so that no pieces get off-stage

# :camera_flash: Screenshots

## Before

![image](https://user-images.githubusercontent.com/677436/92952867-115e6900-f437-11ea-94c0-177c0eb7ea54.png)


## After

![image](https://user-images.githubusercontent.com/677436/92955281-3fde4300-f43b-11ea-821b-8855279ccd44.png)

